### PR TITLE
Fix adjacent views

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,13 @@ declare module 'react-native-swiper' {
     automaticallyAdjustContentInsets?: boolean
     // Enables/Disables swiping
     scrollEnabled?: boolean
+    
+    // If true, it will showcase adjacentViews
+    showAdjacentViews?: boolean
+    // It indicates the visible width of adjacent-view
+    adjacentViewsWidth?: number
+    // It works like margin between the adjacent-view
+    adjacentViewsPadding?: number
   }
 
   export default class Swiper extends Component<SwiperProps, SwiperState> {

--- a/src/index.js
+++ b/src/index.js
@@ -546,6 +546,10 @@ export default class extends Component {
     // parseInt() ensures it's always an integer
     index = parseInt(index + Math.round(diff / step))
 
+    // During onLayout we fire one autoScroll and we need to maintain that same offset when we loop through
+    // to give us accurate index, so step is full width of element including the padding
+    // therefore we deduct the adjacentViewWidth and it's padding to get the accurate offset as before and get accurate index
+    const diffOffset = showAdjacentViews ? adjacentViewsWidth + adjacentViewsPadding : 0;
     if (this.props.loop) {
       if (index <= -1) {
         // If swiping hard to from orignal 0 element user might end up seeing first duplicate element,
@@ -553,20 +557,15 @@ export default class extends Component {
         // otherwise we will scroll to 0 element
         if (offset[dir] <= 0) {
           index = total - 2;
-          offset[dir] = step * total;
+          offset[dir] = step * total - diffOffset;
           loopJump = true;
         } else{
           index = total - 1
-          offset[dir] = step * (total + 1);
+          offset[dir] = step * (total + 1) - diffOffset;
           loopJump = true
         }
       } else if (index >= total || offset[dir] > totalOffsetScreen) {
-         // During onLayout we fire one autoScroll and we need to maintain that same offset when we loop through
-         // to give us accurate index, so step is full width of element including the padding
-         // therefore we deduct the adjacentViewWidth and it's padding to get the accurate offset as before and get accurate index
-        const diffOffset = showAdjacentViews
-          ? adjacentViewsWidth + adjacentViewsPadding
-          : 0;
+
         // If swiping hard to from orignal last element user might end up seeing last duplicate element,
         // which is actually second element of array so we manually scroll to particular that element 
         // otherwise we will scroll to last element
@@ -832,7 +831,7 @@ export default class extends Component {
         style={[
           styles.buttonWrapper,
           {
-            width: this.state.width,
+            width: Dimensions.get('window').width,
             height: this.state.height
           },
           this.props.buttonWrapperStyle
@@ -941,8 +940,7 @@ export default class extends Component {
             (loop && i === pages.length - 3 && index === 0) ||
             (loop && i === pages.length - 2 && index === 0) ||
             (loop && i === 2 && index === total - 1) ||
-            (loop && i === 1 && index === total - 1) ||
-            (loop && i === 1 && index === 0)
+            (loop && i === 1 && index === total - 1)
           ) {
             return (
               <View style={pageStyle} key={i}>

--- a/src/index.js
+++ b/src/index.js
@@ -551,7 +551,7 @@ export default class extends Component {
         // If swiping hard to from orignal 0 element user might end up seeing first duplicate element,
         // which is actually second last element of array so we manually scroll to particular that element 
         // otherwise we will scroll to 0 element
-        if (offset[dir] < 0) {
+        if (offset[dir] <= 0) {
           index = total - 2;
           offset[dir] = step * total;
           loopJump = true;
@@ -570,7 +570,7 @@ export default class extends Component {
         // If swiping hard to from orignal last element user might end up seeing last duplicate element,
         // which is actually second element of array so we manually scroll to particular that element 
         // otherwise we will scroll to last element
-        if (offset[dir] >= totalOffsetScreen + width) {
+        if (offset[dir] > totalOffsetScreen + width) {
           index = 1;
           offset[dir] = step * 3 - diffOffset;
           loopJump = true;
@@ -902,7 +902,7 @@ export default class extends Component {
     } = this.props
     // let dir = state.dir
     // let key = 0
-    const loopVal = loop ? 1 : 0
+    const loopVal = loop ? 2 : 0
     let pages = []
     let paddingHorizontal = showAdjacentViews ? adjacentViewsPadding : 0;
 
@@ -935,14 +935,14 @@ export default class extends Component {
           if (
             (i >= index + loopVal - loadMinimalSize &&
               i <= index + loopVal + loadMinimalSize) ||
-            // We make sure our duplicate elements which are added in 
-            // start and end of swiper are always visible along with real first and last element
-            (loop && i === 0) ||
-            (loop && i === 1) ||
-            (loop && i === 2) ||
-            (loop && i === pages.length - 1) ||
-            (loop && i === pages.length - 2) ||
-            (loop && i === pages.length - 3)
+            // when at 0 index we will force render the real last element and first duplicate element of end list so we don't see any blank jumps when looping,
+            // also when we are at last index value, we will force render the real first element and first duplicate element of start list so we don't see any blank jumps when looping.
+            // this approach will give less re-renders and we can lazy load more elements
+            (loop && i === pages.length - 3 && index === 0) ||
+            (loop && i === pages.length - 2 && index === 0) ||
+            (loop && i === 2 && index === total - 1) ||
+            (loop && i === 1 && index === total - 1) ||
+            (loop && i === 1 && index === 0)
           ) {
             return (
               <View style={pageStyle} key={i}>

--- a/src/index.js
+++ b/src/index.js
@@ -476,10 +476,10 @@ export default class extends Component {
         }
       }
     }
-
-    if (this.props.showAdjacentViews && this.state.dir === 'x') {
-      e.nativeEvent.contentOffset.x = e.nativeEvent.contentOffset.x - (3 * this.internals.adjacentViewDiffWidth)
-    }
+    // It breaks index values with greater adjacentWidth and padding
+    // if (this.props.showAdjacentViews && this.state.dir === 'x') {
+    //   e.nativeEvent.contentOffset.x = e.nativeEvent.contentOffset.x - (3 * this.internals.adjacentViewDiffWidth)
+    // }
 
     this.updateIndex(e.nativeEvent.contentOffset, this.state.dir, () => {
       this.autoplay()

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,9 @@ const styles = {
 
 // missing `module.exports = exports['default'];` with babel6
 // export default React.createClass({
+
+const decelerationRate=0.7
+
 export default class extends Component {
   /**
    * Props Validation
@@ -874,7 +877,7 @@ export default class extends Component {
         style={this.props.scrollViewStyle}
         snapToOffsets={pages.map((x, i) => (i * (this.state.width) - this.props.adjacentViewsWidth - this.props.adjacentViewsPadding))}
         snapToAlignment={'center'}
-        decelerationRate={0}
+        decelerationRate={decelerationRate}
       >
         {pages}
       </ScrollView>

--- a/src/index.js
+++ b/src/index.js
@@ -355,6 +355,11 @@ export default class extends Component {
     if (!this.state.loopJump) return
     const i = this.state.index + (this.props.loop ? 1 : 0)
     const scrollView = this.scrollView
+    const offsetDiff = this.props.adjacentViewsWidth + this.props.adjacentViewsPadding
+    // RN-SWIPER duplicates last element in start and first element in last
+    // So when we swipe from 0 to last-element (Which is duplicate element) or last-element to 0 (Which is duplicate element), 
+    // RN-SWIPER will fire this function to manually scroll to actual element 
+    // So we need to add our customOffset which is considered while loop jumping
     this.loopJumpTimer = setTimeout(
       () => {
         if (scrollView.setPageWithoutAnimation) {
@@ -364,7 +369,7 @@ export default class extends Component {
             scrollView.scrollTo(
               this.props.horizontal === false
                 ? { x: 0, y: this.state.height, animated: false }
-                : { x: this.state.width, y: 0, animated: false }
+                : { x: this.state.width - offsetDiff, y: 0, animated: false }
             )
           } else if (this.state.index === this.state.total - 1) {
             this.props.horizontal === false
@@ -374,7 +379,7 @@ export default class extends Component {
                 animated: false
               })
               : this.scrollView.scrollTo({
-                x: this.state.width * this.state.total,
+                x: (this.state.width * this.state.total) - offsetDiff,
                 y: 0,
                 animated: false
               })


### PR DESCRIPTION
### Is it a bugfix ?
- No

### Is it a new feature ?
- Add support for showing adjacent views in horizontal view
- Added 3 new props showAdjacentViews, adjacentViewsWidth, adjacentViewsPadding.

 Prop  |               Default                |   Type    | Description                                                    |
| :---- | :----------------------------------: | :-------: | :------------------------------------------------------------- |
| showAdjacentViews |                false           |  `bool`  |  If true it will display adjacent views              |    
| adjacentViewsWidth |                8                |  `number`  |  Indicates how much width should be displayed of adjacent view, If showAdjacentViews is false it will be ignored.  |    
| adjacentViewsPadding |            4            |  `number`  |  Indicates the gap between adjacent views, If showAdjacentViews is false it will be ignored.  |                                                   

### Describe what you've done:

- Width of item-Container and lazy-Item-Container will be calculated in context of showAdjacentViews, adjacentViewsWidth, adjacentViewsPadding.
- Instead of duplicating only 1 elements in start and end, now it duplicated 2 elements. So autoplay feature can work with 0 readjusts.
- Duplicate elements, first real element and last real element will always be visible so when autoplay is on, user won't see blank spots.
- Unless and until user swipes hard to scroll to last duplicate element in start or end, only then they will see a little readjust after scroll but index position will always be remembered.
- Using snapToOffsets to get the proper swipe feature to display our adjacentViews. 

